### PR TITLE
Fixed pointer name for Tickrate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,34 +3,34 @@
 ## Memory addresses
 ### Shadow of Chernobyl v1.0000
 
-| Binary            | Offset1    | Offset2 | Offset3 | Offset4 | Offset5 | Offset6 |  Offset7  |  Offset8  |  Type     | Name             | Description                                                                                                               |
-| ----------------- | ---------- |  -----  |  ----   |  ----   |  ----   |  ----   |   ----    |   ----    |  ------   | ---------------  | ----------------------------------------------------------------------------------------------------------------          |
-| xrNetServer.dll   | 0xFAC4     |         |         |         |         |         |           |           |  bool     | Loading          | `true` while loading a level or save                                                                                      |
-| xrCore.dll        | 0xBA040    |  0x4    |  0x0    |  0x40   |  0x8    |  0x20   |   0x14    |           |  string   | CurMap           | Displays currently loaded level name                                                                                      |
-| xrGame.dll        | 0x54C2F9   |         |         |         |         |         |           |           |  bool     | NoControl        | `true` while in-game cinematic cutscene is playing. Or when player is being at level transition prompt                    |
-| XR_3DA.exe        | 0x104928   |         |         |         |         |         |           |           |  float    | sync             | Tickrate of the game                                                                                                      |
-| XR_3DA.exe        | 0x10A878   |  0xBC   |         |         |         |         |           |           |  string   | End              | Displays name of video file of any Wishgranter endings                                                                    |
-| XR_3DA.exe        | 0x4163C    |  0xD30  |         |         |         |         |           |           |  string   | TrueEnd          | Same purpose as End pointer, but for a name of video file of True Ending, when Strelok destroys C-Consciousness           |
+|  Type     | Name             | Description                                                                                                               |
+|  ------   | ---------------  | ----------------------------------------------------------------------------------------------------------------          |
+|  bool     | Loading          | `true` while loading a level or save                                                                                      |
+|  string   | CurMap           | Displays currently loaded level name                                                                                      |
+|  bool     | NoControl        | `true` while in-game cinematic cutscene is playing. Or when player is being at level transition prompt                    |
+|  float    | sync             | Tickrate of the game                                                                                                      |
+|  string   | End              | Displays name of video file of any Wishgranter endings                                                                    |
+|  string   | TrueEnd          | Same purpose as End pointer, but for a name of video file of True Ending, when Strelok destroys C-Consciousness           |
 
 ### Shadow of Chernobyl v1.0006
-| Binary            | Offset1    | Offset2 | Offset3 | Offset4 | Offset5 | Offset6 |  Offset7  |  Offset8  |  Type     | Name             | Description                                                                                                               |
-| ----------------- | ---------- |  -----  |  ----   |  ----   |  ----   |  ----   |   ----    |   ----    |  ------   | ---------------  | ----------------------------------------------------------------------------------------------------------------          |
-| xrNetServer.dll   | 0x13E84    |         |         |         |         |         |           |           |  bool     | Loading          | `true` while loading a level or save                                                                                      |
-| xrCore.dll        | 0xBF368    |  0x4    |  0x0    |  0x40   |  0x8    |  0x28   |   0x4     |           |  string   | CurMap           | Displays currently loaded level name                                                                                      |
-| xrGame.dll        | 0x560668   |         |         |         |         |         |           |           |  bool     | NoControl        | `true` while in-game cinematic cutscene is playing. Or when player is being at level transition prompt                    |
-| XR_3DA.exe        | 0x10BE80   |         |         |         |         |         |           |           |  float    | sync             | Tickrate of the game                                                                                                      |
-| XR_3DA.exe        | 0x171DD4   |  0x180  |         |         |         |         |           |           |  string   | End              | Displays name of video file of any Wishgranter endings                                                                    |
-| XR_3DA.exe        | 0x7D0F8    |  0x1CE  |         |         |         |         |           |           |  string   | TrueEnd          | Same purpose as End pointer, but for a name of video file of True Ending, when Strelok destroys C-Consciousness           |
+|  Type     | Name             | Description                                                                                                               |
+|  ------   | ---------------  | ----------------------------------------------------------------------------------------------------------------          |
+|  bool     | Loading          | `true` while loading a level or save                                                                                      |
+|  string   | CurMap           | Displays currently loaded level name                                                                                      |
+|  bool     | NoControl        | `true` while in-game cinematic cutscene is playing. Or when player is being at level transition prompt                    |
+|  float    | sync             | Tickrate of the game                                                                                                      |
+|  string   | End              | Displays name of video file of any Wishgranter endings                                                                    |
+|  string   | TrueEnd          | Same purpose as End pointer, but for a name of video file of True Ending, when Strelok destroys C-Consciousness           |
 
 ### Clear Sky 1.5.10
-| Binary            | Offset1    | Offset2 | Offset3 | Offset4 | Offset5 | Offset6 |  Offset7  |  Offset8  |  Type     | Name             | Description                                                                                                               |
-| ----------------- | ---------- |  -----  |  ----   |  ----   |  ----   |  ----   |   ----    |   ----    |  ------   | ---------------  | ----------------------------------------------------------------------------------------------------------------          |
-| xrGame.dll        | 0x2A6B19   |  0xE1   |         |         |         |         |           |           |  string   | Start            | Displays name of video file of Intro cutscene                                                                             |
-| xrNetServer.dll   | 0x13E04    |         |         |         |         |         |           |           |  bool     | Loading          | `true` while loading a level or save                                                                                      |
-| xrCore.dll        | 0xBE718    |  0x18   |  0x28   |  0x0    |         |         |           |           |  string   | CurMap           | Displays currently loaded level name                                                                                      |
-| xrGame.dll        | 0x606320   |         |         |         |         |         |           |           |  bool     | NoControl        | `true` while in-game cinematic cutscene is playing. Or when player is being at level transition prompt                    |
-| xrEngine.exe      | 0x96D50    |         |         |         |         |         |           |           |  float    | Sync             | Tickrate of the game                                                                                                      |
-| xrEngine.exe      | 0x96CC0    |  0x30   |  0x10   |  0x4    |  0x34   |  0x4    |   0xC     |   0x16    |  string   | End              | Displays name of video file of Ending cutscene                                                                            |
+|  Type     | Name             | Description                                                                                                               |
+|  ------   | ---------------  | ----------------------------------------------------------------------------------------------------------------          |
+|  string   | Start            | Displays name of video file of Intro cutscene                                                                             |
+|  bool     | Loading          | `true` while loading a level or save                                                                                      |
+|  string   | CurMap           | Displays currently loaded level name                                                                                      |
+|  bool     | NoControl        | `true` while in-game cinematic cutscene is playing. Or when player is being at level transition prompt                    |
+|  float    | Sync             | Tickrate of the game                                                                                                      |
+|  string   | End              | Displays name of video file of Ending cutscene                                                                            |
 
 
 ## Level names

--- a/README.md
+++ b/README.md
@@ -1,0 +1,88 @@
+# S.T.A.L.K.E.R. Trilogy Autoplitter
+
+## Memory addresses
+### Shadow of Chernobyl v1.0000
+
+| Binary            | Offset1    | Offset2 | Offset3 | Offset4 | Offset5 | Offset6 |  Offset7  |  Offset8  |  Type     | Name             | Description                                                                                                               |
+| ----------------- | ---------- |  -----  |  ----   |  ----   |  ----   |  ----   |   ----    |   ----    |  ------   | ---------------  | ----------------------------------------------------------------------------------------------------------------          |
+| xrNetServer.dll   | 0xFAC4     |         |         |         |         |         |           |           |  bool     | Loading          | `true` while loading a level or save                                                                                      |
+| xrCore.dll        | 0xBA040    |  0x4    |  0x0    |  0x40   |  0x8    |  0x20   |   0x14    |           |  string   | CurMap           | Displays currently loaded level name                                                                                      |
+| xrGame.dll        | 0x54C2F9   |         |         |         |         |         |           |           |  bool     | NoControl        | `true` while in-game cinematic cutscene is playing. Or when player is being at level transition prompt                    |
+| XR_3DA.exe        | 0x104928   |         |         |         |         |         |           |           |  float    | sync             | Tickrate of the game                                                                                                      |
+| XR_3DA.exe        | 0x10A878   |  0xBC   |         |         |         |         |           |           |  string   | End              | Displays name of video file of any Wishgranter endings                                                                    |
+| XR_3DA.exe        | 0x4163C    |  0xD30  |         |         |         |         |           |           |  string   | TrueEnd          | Same purpose as End pointer, but for a name of video file of True Ending, when Strelok destroys C-Consciousness           |
+
+### Shadow of Chernobyl v1.0006
+| Binary            | Offset1    | Offset2 | Offset3 | Offset4 | Offset5 | Offset6 |  Offset7  |  Offset8  |  Type     | Name             | Description                                                                                                               |
+| ----------------- | ---------- |  -----  |  ----   |  ----   |  ----   |  ----   |   ----    |   ----    |  ------   | ---------------  | ----------------------------------------------------------------------------------------------------------------          |
+| xrNetServer.dll   | 0x13E84    |         |         |         |         |         |           |           |  bool     | Loading          | `true` while loading a level or save                                                                                      |
+| xrCore.dll        | 0xBF368    |  0x4    |  0x0    |  0x40   |  0x8    |  0x28   |   0x4     |           |  string   | CurMap           | Displays currently loaded level name                                                                                      |
+| xrGame.dll        | 0x560668   |         |         |         |         |         |           |           |  bool     | NoControl        | `true` while in-game cinematic cutscene is playing. Or when player is being at level transition prompt                    |
+| XR_3DA.exe        | 0x10BE80   |         |         |         |         |         |           |           |  float    | sync             | Tickrate of the game                                                                                                      |
+| XR_3DA.exe        | 0x171DD4   |  0x180  |         |         |         |         |           |           |  string   | End              | Displays name of video file of any Wishgranter endings                                                                    |
+| XR_3DA.exe        | 0x7D0F8    |  0x1CE  |         |         |         |         |           |           |  string   | TrueEnd          | Same purpose as End pointer, but for a name of video file of True Ending, when Strelok destroys C-Consciousness           |
+
+### Clear Sky 1.5.10
+| Binary            | Offset1    | Offset2 | Offset3 | Offset4 | Offset5 | Offset6 |  Offset7  |  Offset8  |  Type     | Name             | Description                                                                                                               |
+| ----------------- | ---------- |  -----  |  ----   |  ----   |  ----   |  ----   |   ----    |   ----    |  ------   | ---------------  | ----------------------------------------------------------------------------------------------------------------          |
+| xrGame.dll        | 0x2A6B19   |  0xE1   |         |         |         |         |           |           |  string   | Start            | Displays name of video file of Intro cutscene                                                                             |
+| xrNetServer.dll   | 0x13E04    |         |         |         |         |         |           |           |  bool     | Loading          | `true` while loading a level or save                                                                                      |
+| xrCore.dll        | 0xBE718    |  0x18   |  0x28   |  0x0    |         |         |           |           |  string   | CurMap           | Displays currently loaded level name                                                                                      |
+| xrGame.dll        | 0x606320   |         |         |         |         |         |           |           |  bool     | NoControl        | `true` while in-game cinematic cutscene is playing. Or when player is being at level transition prompt                    |
+| xrEngine.exe      | 0x96D50    |         |         |         |         |         |           |           |  float    | Sync             | Tickrate of the game                                                                                                      |
+| xrEngine.exe      | 0x96CC0    |  0x30   |  0x10   |  0x4    |  0x34   |  0x4    |   0xC     |   0x16    |  string   | End              | Displays name of video file of Ending cutscene                                                                            |
+
+
+## Level names
+
+These are the internal location names that you get when you read the memory address mentioned above.
+
+### Shadow of Chernobyl
+
+| Level                   | Internal name               |
+| ----------------------- | -------------------------   |
+| Cordon                  | escape\                     |
+| Garbage                 | garbage\                    |
+| Agroprom                | agroprom\                   |
+| Agroprom Underground    | _agr_underground\           |
+| Dark Valley             | darkvalley\                 |
+| Lab X-18                | _labx18\                    |
+| Rostok(100 RAD's Bar)   | bar\                        |
+| Wild Territory          | rostok\                     |
+| Yantar                  | yantar\                     |
+| Lab X-16                | _brainlab\                  |
+| Army Warehouses         | military\                   |
+| Radar(aka Red Forest)   | radar\                      |
+| Lab X-19                | _bunker\                    |
+| Pripyat                 | pripyat\                    |
+| Chernobyl NPP           | stancia\                    |
+| Sarcophagus             | _sarcofag\                  |
+| Monolith Control Center | _control_monolith\          |
+| Chernobyl NPP (North)   | stancia_2\                  |
+
+### Clear Sky
+
+| Level                   | Internal name               |
+| ----------------------- | -------------------------   |
+| Swamps                  | marsh\                      |
+| Cordon                  | escape\                     |
+| Garbage                 | garbage\                    |
+| Agroprom                | agroprom\                   |
+| Agroprom Underground    | agroprom_underground\       |
+| Dark Valley             | darkvalley\                 |
+| Yantar                  | yantar\                     |
+| Army Warehouses         | military\                   |
+| Red Forest              | red_forest\                 |
+| Limansk                 | limansk\                    |
+| Deserted Hospital       | hospital\                   |
+| Chernobyl NPP (North)   | stancia_2\                  |
+
+### Call of Pripyat
+
+| Level                   | Internal name               |
+| ----------------------- | -------------------------   |
+| Zaton                   | zaton\                      |
+| Area around Jupiter     | jupiter\                    |
+| Jupiter Underground     | jupiter_underground\        |
+| Pripyat                 | pripyat\                    |
+| Lab X-8                 | labx8\                      |

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@
 
 ## Shadow of Chernobyl Wishgranter endings
 
+These are the internal Wish Granter ending names that you get when you read the memory address mentioned above.
+
 | Ending                          | Internal name               |
 | ------------------------------- | -------------------------   |
 | I want immortality              | final_immortal.ogm          |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 |  string   | End              | Displays name of video file of any Wishgranter endings                                                                    |
 |  string   | TrueEnd          | Same purpose as End pointer, but for a name of video file of True Ending, when Strelok destroys C-Consciousness           |
 
-### Clear Sky 1.5.10
+### Clear Sky v1.5.10
 |  Type     | Name             | Description                                                                                                               |
 |  ------   | ---------------  | ----------------------------------------------------------------------------------------------------------------          |
 |  string   | Start            | Displays name of video file of Intro cutscene                                                                             |
@@ -22,6 +22,17 @@
 |  float    | Sync             | Tickrate of the game                                                                                                      |
 |  string   | End              | Displays name of video file of Ending cutscene                                                                            |
 
+
+
+## Shadow of Chernobyl Wishgranter endings
+
+| Ending                          | Internal name               |
+| ------------------------------- | -------------------------   |
+| I want immortality              | final_immortal.ogm          |
+| I want to rule the world        | final_to_monolith.ogm       |
+| I want to be rich               | final_gold.ogm              |
+| I want the zone to disappear    | final_blind.ogm             |
+| Mankind must be controlled      | final_apocal.ogm            |
 
 ## Level names
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,8 @@
 # S.T.A.L.K.E.R. Trilogy Autoplitter
 
 ## Memory addresses
-### Shadow of Chernobyl v1.0000
+### Shadow of Chernobyl v1.0000-v1.0006
 
-|  Type     | Name             | Description                                                                                                               |
-|  ------   | ---------------  | ----------------------------------------------------------------------------------------------------------------          |
-|  bool     | Loading          | `true` while loading a level or save                                                                                      |
-|  string   | CurMap           | Displays currently loaded level name                                                                                      |
-|  bool     | NoControl        | `true` while in-game cinematic cutscene is playing. Or when player is being at level transition prompt                    |
-|  float    | sync             | Tickrate of the game                                                                                                      |
-|  string   | End              | Displays name of video file of any Wishgranter endings                                                                    |
-|  string   | TrueEnd          | Same purpose as End pointer, but for a name of video file of True Ending, when Strelok destroys C-Consciousness           |
-
-### Shadow of Chernobyl v1.0006
 |  Type     | Name             | Description                                                                                                               |
 |  ------   | ---------------  | ----------------------------------------------------------------------------------------------------------------          |
 |  bool     | Loading          | `true` while loading a level or save                                                                                      |

--- a/stalkercallofpripyatloadremoval.asl
+++ b/stalkercallofpripyatloadremoval.asl
@@ -4,7 +4,7 @@ state("xrEngine", "1.6.02")
 	bool Load2:   0x913F5;
 	byte OnLoad:  0x92E84;
 	string20 CurMap: "xrCore.dll", 0xBE910, 0x18, 0x28, 0x0;
-	float onSync: "xrEngine.exe", 0x92EF4;
+	float sync: "xrEngine.exe", 0x92EF4;
 	string5 End: "xrGame.dll", 0x36C75D, 0xB0;
 	string5 End2: "xrSound.dll", 0x27692, 0xACA;
 }
@@ -56,7 +56,7 @@ isLoading
 
 start
 {
-    return current.onSync > 0.001 && current.onSync < 0.11 && (old.onSync == 0 && current.onSync != old.onSync) && current.Loading;
+    return current.sync > 0.001 && current.sync < 0.11 && (old.sync == 0 && current.sync != old.sync) && current.Loading;
 }
 
 split

--- a/stalkerclearskyloadremoval.asl
+++ b/stalkerclearskyloadremoval.asl
@@ -1,7 +1,7 @@
 state("xrEngine", "1.5.10")
 {
 	bool Loading: "xrNetServer.dll", 0x13E04;
-	float onSync: "xrEngine.exe", 0x96D50;
+	float Sync: "xrEngine.exe", 0x96D50;
 	bool NoControl: "xrGame.dll", 0x606320;
 	string5 Start: "xrGame.dll", 0x2A6B19, 0xE1;
 	string21 CurMap: "xrCore.dll", 0xBE718, 0x18, 0x28, 0x0;
@@ -49,7 +49,7 @@ start
 
 split
 {
-    if (current.CurMap != old.CurMap && !current.Loading && current.sync != 0 && settings["autosplitter"] || current.End == "outro_half")
+    if (current.CurMap != old.CurMap && !current.Loading && current.Sync != 0 && settings["autosplitter"] || current.End == "outro_half")
 	{
 		vars.doneMaps.Add(current.CurMap);
 		return true;
@@ -63,7 +63,7 @@ onReset
 
 isLoading
 {
-	return !current.Loading || (current.onSync>0.09 && current.onSync<0.11);
+	return !current.Loading || (current.Sync>0.09 && current.Sync<0.11);
 }
 
 exit

--- a/stalkertrilogyloadremoval.asl
+++ b/stalkertrilogyloadremoval.asl
@@ -20,7 +20,7 @@ state("XR_3DA","1.0000")
 state("xrEngine", "1.5.10")
 {
 	bool Loading: "xrNetServer.dll", 0x13E04;
-	float onSync: "xrEngine.exe", 0x96D50;
+	float sync: "xrEngine.exe", 0x96D50;
 	bool NoControl: "xrGame.dll", 0x606320;
 	string5 Start: "xrGame.dll", 0x2A6B19, 0xE1;
 	string21 CurMap: "xrCore.dll", 0xBE718, 0x18, 0x28, 0x0;
@@ -33,7 +33,7 @@ state("xrEngine", "1.6.02")
 	bool Load2:   0x913F5;
 	byte OnLoad:  0x92E84;
 	string20 CurMap: "xrCore.dll", 0xBE910, 0x18, 0x28, 0x0;
-	float onSync: "xrEngine.exe", 0x92EF4;
+	float sync: "xrEngine.exe", 0x92EF4;
 	string5 End: "xrGame.dll", 0x36C75D, 0xB0;
 	string5 End2: "xrSound.dll", 0x27692, 0xACA;
 }
@@ -153,7 +153,7 @@ isLoading
 	}
 	else if(version == "1.5.10")
 	{
-		return !current.Loading || (current.onSync>0.09 && current.onSync<0.11);
+		return !current.Loading || (current.sync>0.09 && current.sync<0.11);
 	}
 	else if(version == "1.6.02")
 	{


### PR DESCRIPTION
Clear Sky script will fail to work, because of wrong pointer name in isLoading function.
Also renamed the pointer on the rest of scripts, to keep consistency.